### PR TITLE
Closes #98 Close duplicate: Metric calculation discrepancy

### DIFF
--- a/__bak8/HighestSetBitTest.java
+++ b/__bak8/HighestSetBitTest.java
@@ -1,0 +1,39 @@
+package com.thealgorithms.bitmanipulation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for Highest Set Bit
+ * @author Bama Charan Chhandogi (https://github.com/BamaCharanChhandogi)
+ */
+
+class HighestSetBitTest {
+
+    @Test
+    void testHighestSetBit() {
+        assertFalse(HighestSetBit.findHighestSetBit(0).isPresent());
+        assertEquals(0, HighestSetBit.findHighestSetBit(1).get());
+        assertEquals(1, HighestSetBit.findHighestSetBit(2).get());
+        assertEquals(1, HighestSetBit.findHighestSetBit(3).get());
+        assertEquals(2, HighestSetBit.findHighestSetBit(4).get());
+        assertEquals(2, HighestSetBit.findHighestSetBit(5).get());
+        assertEquals(2, HighestSetBit.findHighestSetBit(7).get());
+        assertEquals(3, HighestSetBit.findHighestSetBit(8).get());
+        assertEquals(3, HighestSetBit.findHighestSetBit(9).get());
+        assertEquals(3, HighestSetBit.findHighestSetBit(15).get());
+        assertEquals(4, HighestSetBit.findHighestSetBit(16).get());
+        assertEquals(4, HighestSetBit.findHighestSetBit(17).get());
+        assertEquals(4, HighestSetBit.findHighestSetBit(31).get());
+        assertEquals(5, HighestSetBit.findHighestSetBit(32).get());
+        assertEquals(5, HighestSetBit.findHighestSetBit(33).get());
+        assertEquals(7, HighestSetBit.findHighestSetBit(255).get());
+        assertEquals(8, HighestSetBit.findHighestSetBit(256).get());
+        assertEquals(8, HighestSetBit.findHighestSetBit(511).get());
+        assertEquals(9, HighestSetBit.findHighestSetBit(512).get());
+        assertThrows(IllegalArgumentException.class, () -> HighestSetBit.findHighestSetBit(-37));
+    }
+}

--- a/__bak8/SimpleNode.java
+++ b/__bak8/SimpleNode.java
@@ -1,0 +1,59 @@
+package com.thealgorithms.devutils.nodes;
+
+/**
+ * Simple Node implementation that holds a reference to the next Node.
+ *
+ * @param <E> The type of the data held in the Node.
+ *
+ * @author <a href="https://github.com/aitorfi">aitorfi</a>
+ */
+public class SimpleNode<E> extends Node<E> {
+
+    /**
+     * Reference to the next Node.
+     */
+    private SimpleNode<E> nextNode;
+
+    /**
+     * Empty constructor.
+     */
+    public SimpleNode() {
+        super();
+    }
+
+    /**
+     * Initializes the Nodes' data.
+     *
+     * @param data Value to which data will be initialized.
+     * @see Node#Node(Object)
+     */
+    public SimpleNode(E data) {
+        super(data);
+    }
+
+    /**
+     * Initializes the Nodes' data and next node reference.
+     *
+     * @param data Value to which data will be initialized.
+     * @param nextNode Value to which the next node reference will be set.
+     */
+    public SimpleNode(E data, SimpleNode<E> nextNode) {
+        super(data);
+        this.nextNode = nextNode;
+    }
+
+    /**
+     * @return True if there is a next node, otherwise false.
+     */
+    public boolean hasNext() {
+        return (nextNode != null);
+    }
+
+    public SimpleNode<E> getNextNode() {
+        return nextNode;
+    }
+
+    public void setNextNode(SimpleNode<E> nextNode) {
+        this.nextNode = nextNode;
+    }
+}


### PR DESCRIPTION
98 Clarified the token length limitations for sequence-based LLMs in the API documentation. This PR adds a warning to the inference engine when an input sequence exceeds the maximum context window of 8k tokens. Included a strategy for sliding-window analysis for longer genomic contigs.